### PR TITLE
Feature/aqualab

### DIFF
--- a/src/ogd/games/AQUALAB/AqualabLoader.py
+++ b/src/ogd/games/AQUALAB/AqualabLoader.py
@@ -189,6 +189,10 @@ class AqualabLoader(GeneratorLoader):
                     ret_val = PopulationJobCompletionProgression.PopulationJobCompletionProgression(params=extractor_params)
                 case "PopulationJobSwitchProgression":
                     ret_val = PopulationJobSwitchProgression.PopulationJobSwitchProgression(params=extractor_params)
+                case "LanguageSelected":    
+                    ret_val = LanguageSelected.LanguageSelected(params=extractor_params)
+                case "PlayerLanguageSelected":
+                    ret_val = PlayerLanguageSelected.PlayerLanguageSelected(params=extractor_params)
                 case _:
                     Logger.Log(f"'{feature_type}' is not a valid aggregate feature type for Aqualab.")
         # then run through per-count features.

--- a/src/ogd/games/AQUALAB/features/LanguageSelected.py
+++ b/src/ogd/games/AQUALAB/features/LanguageSelected.py
@@ -1,0 +1,69 @@
+# import libraries
+from typing import Any, List, Optional
+
+from ogd.core.generators.Generator import GeneratorParameters
+from ogd.core.generators.extractors.Feature import Feature
+from ogd.common.models.Event import Event
+from ogd.common.models.enums.ExtractionMode import ExtractionMode
+from ogd.common.models.FeatureData import FeatureData
+from ogd.common.utils.Logger import Logger
+import logging
+
+class LanguageSelected(Feature):
+    def __init__(self, params: GeneratorParameters):
+        super().__init__(params=params)
+        self.session_languages = {}
+        self.player_sessions = {}
+    
+    @classmethod
+    def _eventFilter(cls, mode: ExtractionMode) -> List[str]:
+        return ["all_events"]
+
+    @classmethod
+    def _featureFilter(cls, mode: ExtractionMode) -> List[str]:
+        return []
+
+    def _updateFromEvent(self, event: Event) -> None:
+        session_id = event.SessionID
+        player_id = event.UserID
+
+        if player_id:
+            if player_id not in self.player_sessions:
+                self.player_sessions[player_id] = [session_id]
+            else:
+                self.player_sessions[player_id].append(session_id)
+
+        if event.EventName == "select_language":
+            language_selected = event.EventData["language"]
+            if self.session_languages.get(session_id, None) is None:
+                self.session_languages[session_id] = language_selected
+            # elif self.session_languages[session_id] != language_selected:
+            #     self.session_languages[session_id] = "BOTH"
+ 
+    def _updateFromFeatureData(self, feature: FeatureData):
+        return
+
+    def _getFeatureValues(self) -> List[Any]:
+        player_languages = {}
+        for player_id, sessions in self.player_sessions.items():
+            session_languages = [self.session_languages.get(session_id, None) for session_id in sessions]
+            if "SPANISH" in session_languages and "ENGLISH" in session_languages:
+                player_languages[player_id] = "BOTH"
+            elif "SPANISH" in session_languages:
+                player_languages[player_id] = "SPANISH"
+            elif "ENGLISH" in session_languages:
+                player_languages[player_id] = "ENGLISH"
+            else:
+                player_languages[player_id] = "ENGLISH"
+        return [player_languages]
+
+    def Subfeatures(self) -> List[str]:
+        return []
+
+    @staticmethod
+    def MinVersion() -> Optional[str]:
+        return "1"
+    
+    @classmethod
+    def AvailableModes(cls) -> List[ExtractionMode]:
+        return [ExtractionMode.POPULATION]

--- a/src/ogd/games/AQUALAB/features/PlayerLanguageSelected.py
+++ b/src/ogd/games/AQUALAB/features/PlayerLanguageSelected.py
@@ -1,0 +1,47 @@
+# import libraries
+from typing import Any, List, Optional
+
+from ogd.core.generators.Generator import GeneratorParameters
+from ogd.core.generators.extractors.Feature import Feature
+from ogd.common.models.Event import Event
+from ogd.common.models.enums.ExtractionMode import ExtractionMode
+from ogd.common.models.FeatureData import FeatureData
+from ogd.common.utils.Logger import Logger
+import logging
+
+class PlayerLanguageSelected(Feature):
+    def __init__(self, params: GeneratorParameters):
+        super().__init__(params=params)
+        self.player_id = None
+        self.player_language = None
+    
+    @classmethod
+    def _eventFilter(cls, mode: ExtractionMode) -> List[str]:
+        return ["all_events"]
+
+    @classmethod
+    def _featureFilter(cls, mode: ExtractionMode) -> List[str]:
+        return ["LanguageSelected"]
+
+    def _updateFromEvent(self, event: Event) -> None:
+        if self.player_id is None and event.UserID is not None:
+            self.player_id = event.UserID
+ 
+    def _updateFromFeatureData(self, feature: FeatureData):
+        if feature.FeatureType == "LanguageSelected":
+            player_languages = feature.FeatureValues[0]
+            self.player_language = player_languages.get(self.player_id, None)
+
+    def _getFeatureValues(self) -> List[Any]:
+        return [self.player_language]
+
+    def Subfeatures(self) -> List[str]:
+        return []
+
+    @staticmethod
+    def MinVersion() -> Optional[str]:
+        return "1"
+    
+    @classmethod
+    def AvailableModes(cls) -> List[ExtractionMode]:
+        return [ExtractionMode.PLAYER]

--- a/src/ogd/games/AQUALAB/features/PopulationJobSwitchProgression.py
+++ b/src/ogd/games/AQUALAB/features/PopulationJobSwitchProgression.py
@@ -45,9 +45,9 @@ class PopulationJobSwitchProgression(Feature):
                         }
                     self.nodes[key]["node_count"] += node["node_count"]
                     self.nodes[key]["percentage_completed"] += node["percentage_completed"]
-                    # Normalize time_spent to timedelta if it's an int
+                    # Normalize time_spent to timedelta if it's int or float (seconds)
                     time_spent = node["time_spent"]
-                    if isinstance(time_spent, int):
+                    if isinstance(time_spent, (int, float)):
                         time_spent = timedelta(seconds=time_spent)
                     self.nodes[key]["time_spent"] += time_spent
         elif feature.FeatureType == "PlayerProgressionLinks":

--- a/src/ogd/games/AQUALAB/features/RegionJobCount.py
+++ b/src/ogd/games/AQUALAB/features/RegionJobCount.py
@@ -16,37 +16,38 @@ class RegionJobCount(PerCountFeature):
     def __init__(self, params:GeneratorParameters):
         super().__init__(params=params)
         regions = ['arctic', 'coral', 'bayou', 'kelp', 'other']
-        self.count = 0
+        self.attemptedCount = 0
+        self.completeCount = 0
         self.region = regions[self.CountIndex]
     # *** IMPLEMENT ABSTRACT FUNCTIONS ***
     @classmethod
     def _eventFilter(cls, mode:ExtractionMode) -> List[str]:
-        return ["complete_job"]
+        return ["complete_job", "switch_job"]
 
     @classmethod
     def _featureFilter(cls, mode:ExtractionMode) -> List[str]:
         return []
 
-    def _validateEventCountIndex(self, event:Event):
-        if event.app_version == 'Aqualab' or event.app_version == 'None':
-            if event.EventData.get('job_name', {}).get('string_value').startswith(self.region):
-                return True
-            else:
-                return False
-        else:
-            if event.EventData.get('job_name', {}).startswith(self.region):
-                return True
-            else:
-                return False
+    def _validateEventCountIndex(self, event:Event) -> bool:
+        job_name = event.GameState.get('job_name')
+        return isinstance(job_name, str) and job_name.startswith(self.region)
+
 # 'aqualab' and 'GameState"
     def _updateFromEvent(self, event:Event) -> None:
-        self.count += 1
+        if event.EventName == "switch_job":
+            self.attemptedCount += 1
+
+        if event.EventName == "complete_job":
+            self.completeCount += 1
 
     def _updateFromFeatureData(self, feature:FeatureData):
         return
 
     def _getFeatureValues(self) -> List[Any]:
-        return [self.count]
+        return [self.attemptedCount, self.completeCount]
+
+    def Subfeatures(self) -> List[str]:
+        return ["Complete"]
 
     # *** Optionally override public functions. ***
     @staticmethod

--- a/src/ogd/games/AQUALAB/features/__init__.py
+++ b/src/ogd/games/AQUALAB/features/__init__.py
@@ -92,6 +92,8 @@ __all__ = [
     "PlayerProgressionLinks",
     "PopulationJobCompletionProgression",
     "PopulationJobSwitchProgression",
+    "LanguageSelected",
+    "PlayerLanguageSelected",
 ]
 
 from . import ActiveJobs
@@ -185,3 +187,5 @@ from . import PlayerProgressionJobNodes
 from . import PlayerProgressionLinks
 from . import PopulationJobCompletionProgression
 from . import PopulationJobSwitchProgression
+from . import LanguageSelected
+from . import PlayerLanguageSelected

--- a/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
+++ b/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
@@ -1601,6 +1601,18 @@
                 "type": "UserTotalSessionDuration",
                 "description": "Total duration of all sessions for a user.",
                 "return_type": "timedelta"
+            },
+            "LanguageSelected": {
+                "enabled": true,
+                "type": "LanguageSelected",
+                "description": "Language selected by the player at the population level.",
+                "return_type": "str"
+            },
+            "PlayerLanguageSelected": {
+                "enabled": true,
+                "type": "PlayerLanguageSelected",
+                "description": "Language selected by the player at the player level.",
+                "return_type": "str"
             }
         }
     },


### PR DESCRIPTION
Added language selection features RegionJobCount.
We currently have [RegionJobCount.py](https://github.com/opengamedata/ogd-core/blob/main/src/ogd/games/AQUALAB/features/RegionJobCount.py), but it’s counting jobs completed
Changed the base feature to report the count of jobs attempted, and made the complete count a subfeature
Jobs “attempted” here will be the number of switch_job whose GameState job name matches the region

Resolves #494 #498 
